### PR TITLE
Added .scss code for "checkbox not showing on chrome" (issue 28)

### DIFF
--- a/assets/scss/_forms.scss
+++ b/assets/scss/_forms.scss
@@ -12,8 +12,12 @@ form {
 }
 
 // insure no borders on mobile safari
-input {
-  -webkit-appearance: none;
+input[type="checkbox"] {
+  -webkit-appearance: checkbox;
+  border-radius: 0;
+}
+input[type="radio"] {
+  -webkit-appearance: radio;
   border-radius: 0;
 }
 


### PR DESCRIPTION
Following the issue at https://github.com/littlesparkvt/flatstrap/issues/28 I noticed that the commit that resolved it was only for the .less code (ab7054b1ca1475f3e03a981459a33fe971008479)

Since I'm using your repository for my gem https://github.com/lucatironi/flatstrap-sass (based on https://github.com/thomas-mcdonald/bootstrap-sass), I thought to change also the .scss code.

Thanks for your consideration and your amazing work.
